### PR TITLE
Avoid tailwind-merge dependency in cn utility

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,5 @@
+import { clsx, type ClassValue } from "clsx";
+
+export function cn(...inputs: ClassValue[]): string {
+  return clsx(inputs);
+}


### PR DESCRIPTION
## Summary
- implement the `cn` helper without relying on `tailwind-merge`
- keep the helper focused on `clsx` so the import no longer fails during Vite analysis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7be132a448327954a86d8eb199710