### PR TITLE
Ensure cn helper returns string

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## Summary
- declare a string return type for the cn utility helper to keep type expectations consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c666e2308327aee2d14aa93ae2c1