### PR TITLE
Add explicit return type to cn utility

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## Summary
- add the explicit `string` return type to the `cn` utility while keeping the `twMerge` behaviour

## Testing
- npm install *(fails: 403 Forbidden fetching @radix-ui/react-avatar)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c7af14248327a7373b48cf2a8e2e