### PR TITLE
Fix cn helper to use tailwind-merge and add dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "framer-motion": "^11.0.3",
     "lucide-react": "^0.363.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,13 +1,6 @@
-<<<<<<< HEAD
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-=======
-import { clsx, type ClassValue } from "clsx";
-
 export function cn(...inputs: ClassValue[]): string {
-  return clsx(inputs);
->>>>>>> origin/codex/fix-tailwind-merge-import-error
+  return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## Summary
- add the missing tailwind-merge dependency so Vite can resolve the module
- update the cn utility to merge class names with tailwind-merge without conflict markers

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui/react-avatar)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cd72a5f0832788d3b780885aadca