### PR TITLE
Fix cn helper to spread class values

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,5 +2,5 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]): string {
-  return twMerge(clsx(inputs));
+  return twMerge(clsx(...inputs));
 }


### PR DESCRIPTION
## Summary
- ensure the `cn` utility spreads class values before merging them

## Testing
- npm run build *(fails: existing JSX.IntrinsicElements typing errors in multiple TSX files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d03414788327847294b61ed3fda0